### PR TITLE
Fix "edit on GitHub" link

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,7 +28,7 @@ layout: default
   </div>
 
   <div class="edit-link-container">
-    <a href="https://github.com/rust-lang-nursery/futures-rs/blob/gh-pages/{{ page.path }}">
+    <a href="https://github.com/rust-lang-nursery/wg-net/blob/gh-pages/{{ page.path }}">
       Edit on GitHub
     </a>
   </div>


### PR DESCRIPTION
The "edit on GitHub" link was broken. This fixes that. Thanks!