### PR TITLE
Fix async equivalent example

### DIFF
--- a/_posts/2018-10-16-tide-routing.md
+++ b/_posts/2018-10-16-tide-routing.md
@@ -93,7 +93,7 @@ To finish out the app, we need to implement the endpoint functions we passed int
 Let's start with the `new_message` endpoint:
 
 ```rust
-async fn new_message(db: AppState<Database>, msg: Json<Message>) -> Display<usize> {    
+async fn new_message(mut db: AppState<Database>, msg: Json<Message>) -> Display<usize> {    
     db.insert(msg.0)
 }
 ```
@@ -102,7 +102,7 @@ First off, we're using `async fn` to write the endpoint.
 This feature, currently available on Nightly, allows you to write futures-based code with ease. The function signature is equivalent to:
 
 ```rust
-fn new_message(mut db: AppState<Database>, msg: Json<Message>) -> impl Future<Output = Display(u64)>
+fn new_message(mut db: AppState<Database>, msg: Json<Message>) -> impl Future<Output = Display(usize)>
 ```
 
 Every endpoint signature has this same form:


### PR DESCRIPTION
Hello,

I'm opening a PR for this but I'm not sure what I did is the proper fix.

Seems like the `async fn` -> `fn` example is missing a `mut` for db, and the return type is  inconsistent (`usize` vs `u64`).