### PR TITLE
Fix typos

### DIFF
--- a/_posts/2018-09-11-tide.md
+++ b/_posts/2018-09-11-tide.md
@@ -26,7 +26,7 @@ Beyond addressing these mismatches, web frameworks sometimes have further ambiti
 - Standard versions of other concerns like thread and connection pools, etc.
 - Workflows for rapid code generation.
 
-This is hard work! It requires a large set of underlying libraries to do the grunt work, and careful design and ergonomic work on top to achieve the desired separation of concerns.
+This is hard work! It requires a large set of underlying libraries to do the grunt work, and careful design and ergonomics work on top to achieve the desired separation of concerns.
 
 ## The vision for Tide
 
@@ -59,13 +59,13 @@ There are some important open questions here:
 
 - While the `http` crate provides basic request and response types, the *body* data is treated generically. So, to establish a standard specialization of `Service` to HTTP, we also need to standardize those types (or constraints around them), which also means accounting for streaming bodies. A [recent post](https://medium.com/@carllerche/tower-web-expanding-the-middleware-stack-f9bf55bfa109) about tower-web proposed one such approach, based on a new `BufStream` trait.
 
-In short, there’s already a very basis for a service abstraction in Rust, and hopefully the working group can help push toward standardization and improvements as needed. This abstraction would also act as the starting point for building Tide.
+In short, there’s already a very solid basis for a service abstraction in Rust, and hopefully the working group can help push toward standardization and improvements as needed. This abstraction would also act as the starting point for building Tide.
 
 ## Routing strategies
 
 Taking the above abstraction for granted, you can view a web framework as a very fancy way of helping you write what is ultimately a single request-to-response function. As explained at the beginning of the post, a lot of the work that a framework does is to separate out concerns so that you can write your core business logic in a natural style.
 
-A starting point for most frameworks is some system for *routing*, which maps URLs and HTTP request types to specific functions that contain business logic — often called *endpoints*. The routing mechanism often a place where some *other* HTTP-centric concerns are dealt with, e.g. validation. Hence, it can be a defining aspect of how a framework fits together.
+A starting point for most frameworks is some system for *routing*, which maps URLs and HTTP request types to specific functions that contain business logic — often called *endpoints*. The routing mechanism is often a place where some *other* HTTP-centric concerns are dealt with, e.g. validation. Hence, it can be a defining aspect of how a framework fits together.
 
 Approaches to routing tend to fall into one of three categories:
 

--- a/_posts/2018-10-16-tide-routing.md
+++ b/_posts/2018-10-16-tide-routing.md
@@ -202,7 +202,7 @@ The design draws ideas liberally from Rocket, Gotham, and Actix-Web, with some n
 For routing, to achieve the clarity goals, we follow these principles:
 
 - Separate out routing via a "table of contents" approach, making it easy to see the overall app structure.
-- No "fallback" in route matching; use match specificity. In particular, the order in which routes are added has no affect, and you cannot have two identical routes.
+- No "fallback" in route matching; use match specificity. In particular, the order in which routes are added has no effect, and you cannot have two identical routes.
 - Drive endpoint selection *solely* by URL and HTTP method. Other aspects of a request can affect middleware and the behavior of the endpoint, but *not* which endpoint is used in the successful case. So for example, middleware can perform authentication and avoid invoking the endpoint on failure, but it does this by explicitly choosing a separate way of providing a response, rather than relying on "fallback" in the router.
 
 At the core of the routing system are several data types:
@@ -281,7 +281,7 @@ impl<AppData> Resource<AppData> {
 
 If there's a mismatch between the number of `{}` or `*` segments and the corresponding `Path` and `Glob` extractors in an endpoint, **the resource builder API will panic on endpoint registration**. Hence, such mismatches are trivially caught before a server even runs.
 
-Most of these methods returns a handle to a `Config`, which makes it possible to tweak the configuration at a route or endpoint level. This post won't go into detail on the configuration API, but the idea is that configuration, like middleware, applies in a hierarchical fashion along the routing table of contents. So, app-level configuration provides a global default, which can then be adjusted at each step along the way down a route (or even parts of a route) and an endpoint.
+Most of these methods return a handle to a `Config`, which makes it possible to tweak the configuration at a route or endpoint level. This post won't go into detail on the configuration API, but the idea is that configuration, like middleware, applies in a hierarchical fashion along the routing table of contents. So, app-level configuration provides a global default, which can then be adjusted at each step along the way down a route (or even parts of a route) and an endpoint.
 
 ## Endpoints
 
@@ -301,7 +301,7 @@ The endpoint is given a handle to the application state and a reference to the c
 Note that the `Endpoint` trait has a `Kind` parameter which is not used in the body of the trait. This additional parameter is what makes it possible to *overload* the mounting APIs to work with  a variety of function signatures. In particular, here's a fragment of some of the provided implementations:
 
 ```rust
-/// A marker structu to avoid overlap
+/// A marker struct to avoid overlap
 struct Ty<T>(T);
 
 // An endpoint implementation for *zero* extractors.


### PR DESCRIPTION
Proofread the texts a bit.

Note about affect/effect: affect is usually a verb, and a verb in that position is not expected, so I replaced it with effect.

`solid` was chosen as a most fitting missing word there in my opinion, can be changed.